### PR TITLE
Update allowed URL in WebView

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,0 +1,44 @@
+# Uncomment this line to define a global platform for your project
+platform :ios, '11.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+  # target 'RunnerTests' do
+  #   inherit! :search_paths
+  # end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/lib/src/flutter_bkash_view.dart
+++ b/lib/src/flutter_bkash_view.dart
@@ -42,10 +42,10 @@ class FlutterBkashViewState extends State<FlutterBkashView> {
           onWebResourceError: (WebResourceError error) =>
               Navigator.of(context).pop(BkashPaymentStatus.failed),
           onNavigationRequest: (NavigationRequest request) {
-            if (request.url.startsWith("https://www.bkash.com/")) {
+            if (request.url.contains("bkash.com")) {
+              //sendbox starts with sandbox.payment.bkash.com and live starts with payment.bkash.com
               return NavigationDecision.navigate;
             }
-
             if (request.url.startsWith(widget.successCallbackURL)) {
               Navigator.of(context).pop(BkashPaymentStatus.successed);
             } else if (request.url.startsWith(widget.failureCallbackURL)) {


### PR DESCRIPTION
Fixes [issue #12](https://github.com/codeboxrcodehub/flutter-bkash/issues/12).

### Problem
The issue was identified as a result of [this reported problem](https://github.com/codeboxrcodehub/flutter-bkash/issues/12), where the WebView was encountering a blank white screen on iOS. The root cause was traced back to the incorrect handling of URLs in the code.

### Solution
The proposed solution corrects the URL validation logic. Previously, the code used `request.url.startsWith("https://www.bkash.com/")`, which proved to be incorrect. The fix now considers that sandbox URLs start with `https://sandbox.payment.bkash.com`, and live URLs start with `https://payment.bkash.com`.

### Changes Made
- Updated the URL validation logic in [flutter_bkash_view.dart](https://github.com/codeboxrcodehub/flutter-bkash/blob/8a7a016868e755aad5a72c6bd1f13302e1aa124c/lib/src/flutter_bkash_view.dart#L45).

